### PR TITLE
fix(form-countdown): resolve incompatibility with Give core 2.1 #29

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -4,12 +4,16 @@
  *
  * @since 1.0
  *
- * @param bool $is_closed
- * @param int  $form_id
+ * @param bool $is_closed   Form closed or open.
+ * @param int  $form_object Form Object.
  *
  * @return bool
  */
-function gfc_form_close( $is_closed, $form_id ) {
+function gfc_form_close( $is_closed, $form_object ) {
+
+	// Get Form ID.
+	$form_id = $form_object->ID;
+
 	// Check if time achieved or not.
 	if ( give_is_limit_donation_time_achieved( $form_id )  && 'close_form' === get_post_meta( $form_id, 'form-countdown-message-achieved-position', true ) ) {
 		return true;


### PR DESCRIPTION
Closes #29 

## Description
The filter `give_is_close_donation_form` wasn't working properly because in Give Core, the argument was changed from passing form ID to form object.

## How Has This Been Tested?
By reloading the form page of an expired form.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.